### PR TITLE
Fix/minor memory leak testing

### DIFF
--- a/django_ontruck/test.py
+++ b/django_ontruck/test.py
@@ -1,12 +1,24 @@
+from weakref import WeakKeyDictionary
+
 import django
 from django.db import DEFAULT_DB_ALIAS
 from django.db.transaction import get_connection, Atomic
-from collections import defaultdict
 from contextlib import ContextDecorator
+
+class WeakKeyDefaultDictionary:
+    def __init__(self, default):
+        self._store = WeakKeyDictionary()
+        self._default = default
+
+    def __getitem__(self, item):
+        return self._store.setdefault(item, self._default())
+
+    def __setitem__(self, key, value):
+        self._store[key] = value
 
 
 class DepthTrackingAtomic(ContextDecorator):
-    atomic_registry = defaultdict(list)
+    atomic_registry = WeakKeyDefaultDictionary(list)
 
     def __init__(self, atomic):
         self._atomic = atomic

--- a/django_ontruck/test.py
+++ b/django_ontruck/test.py
@@ -5,6 +5,7 @@ from django.db import DEFAULT_DB_ALIAS
 from django.db.transaction import get_connection, Atomic
 from contextlib import ContextDecorator
 
+
 class WeakKeyDefaultDictionary:
     def __init__(self, default):
         self._store = WeakKeyDictionary()

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
 bumpversion==0.5.3
 wheel==0.30.0
 Sphinx==2.4.4
-django==2.2
+django==2.2.10


### PR DESCRIPTION
Avoid memory leaks using WeakKeyDictionarys. Entries in the dictionary will be discarded when no there is no longer a strong reference to the key