### PR TITLE
Feature: port remaining signal features(disconnect, receiver) to events

### DIFF
--- a/django_ontruck/events.py
+++ b/django_ontruck/events.py
@@ -1,4 +1,4 @@
-from django.dispatch.dispatcher import receiver as django_receiver
+from django.dispatch.dispatcher import receiver as signal_receiver
 
 
 class EventBase:
@@ -21,4 +21,8 @@ class EventBase:
 
 
 def receiver(event, **kwargs):
-    return django_receiver(event.signal, **kwargs)
+    if isinstance(event, (list, tuple)):
+        events = [e.signal for e in event]
+    else:
+        events = [event.signal]
+    return signal_receiver(events, **kwargs)

--- a/django_ontruck/events.py
+++ b/django_ontruck/events.py
@@ -1,3 +1,5 @@
+from django.dispatch.dispatcher import receiver as django_receiver
+
 
 class EventBase:
     sender = None
@@ -12,3 +14,11 @@ class EventBase:
     @classmethod
     def connect(cls, receiver, sender=None, weak=True, dispatch_uid=None):
         cls.signal.connect(receiver, sender, weak, dispatch_uid)
+
+    @classmethod
+    def disconnect(cls, receiver=None, sender=None, dispatch_uid=None):
+        cls.signal.disconnect(receiver, sender, dispatch_uid)
+
+
+def receiver(event, **kwargs):
+    return django_receiver(event.signal, **kwargs)

--- a/tests/test_app/events/handlers.py
+++ b/tests/test_app/events/handlers.py
@@ -1,2 +1,11 @@
+from django_ontruck.events import receiver
+from tests.test_app.events.events import FooEvent
+
+
 def foo_event_handler(attr1, **kwargs):
+    pass
+
+
+@receiver(FooEvent)
+def foo_event_handler_with_receiver(attr1, **kwargs):
     pass

--- a/tests/test_app/events/handlers.py
+++ b/tests/test_app/events/handlers.py
@@ -9,3 +9,8 @@ def foo_event_handler(attr1, **kwargs):
 @receiver(FooEvent)
 def foo_event_handler_with_receiver(attr1, **kwargs):
     pass
+
+
+@receiver([FooEvent])
+def foo_event_handler_with_list_of_receivers(attr1, **kwargs):
+    pass

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -32,4 +32,9 @@ class TestEvents:
         foo_event.send()
         mock_event_handler.called_once_with(attr1='attr1_value')
 
+    def test_reciver_list(self, mocker, foo_event):
+        mock_event_handler = mocker.patch('tests.test_app.events.handlers.foo_event_handler_with_list_of_receivers')
+        foo_event.send()
+        mock_event_handler.called_once_with(attr1='attr1_value')
+
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -20,3 +20,16 @@ class TestEvents:
         mock_event_handler = mocker.patch('tests.test_app.events.handlers.foo_event_handler')
         foo_event.send()
         mock_event_handler.called_once_with(attr1='attr1_value')
+
+    def test_disconnect(self, mocker, foo_event):
+        mock_event_handler = mocker.patch('tests.test_app.events.handlers.foo_event_handler')
+        foo_event.disconnect()
+        foo_event.send()
+        mock_event_handler.not_called()
+
+    def test_receiver(self, mocker, foo_event):
+        mock_event_handler = mocker.patch('tests.test_app.events.handlers.foo_event_handler_with_receiver')
+        foo_event.send()
+        mock_event_handler.called_once_with(attr1='attr1_value')
+
+


### PR DESCRIPTION
Add some of the remaining methods used in django signals that are useful for `EventBase`.
Keep interfaces as similar as possible.