### PR TITLE
Copy the SortedJsonField from Core

### DIFF
--- a/django_ontruck/serializers.py
+++ b/django_ontruck/serializers.py
@@ -1,0 +1,59 @@
+import json
+from collections import OrderedDict
+
+from rest_framework.fields import JSONField
+
+
+class DictSort:
+    def __init__(self, sort_method):
+        self.sort_method = sort_method
+        self._queue = []
+
+    def _items(self):
+        while True:
+            if self._queue:
+                yield self._queue.pop(0)
+            else:
+                return
+
+    def _enqueue(self, dict_to_sort, current):
+        for key in self.sort_method(dict_to_sort):
+            self._queue.append((key, dict_to_sort[key], current))
+
+    def _handle_item(self, key, value, current):
+        if not isinstance(value, dict):
+            current[key] = value
+
+            return
+
+        current[key] = OrderedDict()
+
+        self._enqueue(value, current[key])
+
+    def __call__(self, dict_to_sort):
+        sorted_dict = OrderedDict()
+
+        self._enqueue(dict_to_sort, sorted_dict)
+
+        for key, value, current in self._items():
+            self._handle_item(key, value, current)
+
+        return sorted_dict
+
+
+class SortedJSONField(JSONField):
+    def __init__(self, *args, **kwargs):
+        self.sort_method = kwargs.pop('sort_method', sorted)
+
+        super().__init__(*args, **kwargs)
+
+    def to_representation(self, value):
+        representation = super().to_representation(value)
+
+        if self.binary:
+            if isinstance(representation, bytes):
+                representation = representation.decode('utf-8')
+
+            return json.dumps(json.loads(representation), sort_keys=True)
+
+        return DictSort(self.sort_method)(representation)

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1,0 +1,76 @@
+import json
+from collections import OrderedDict
+
+from pytest import fixture
+
+from django_ontruck.serializers import DictSort, SortedJSONField
+
+
+class TestSerializers:
+    @fixture
+    def dict_to_sort(self):
+        return {
+            'B': 2,
+            'A': {
+                'D': 4,
+                'C': {
+                    'F': 6,
+                    'E': 5,
+                },
+            }
+        }
+
+    @fixture
+    def sorted_dict(self):
+        return OrderedDict((
+            (
+                'A',
+                OrderedDict(
+                    (
+                        ('C', OrderedDict((('E', 5), ('F', 6)))),
+                        ('D', 4)
+                    )
+                )
+            ),
+            ('B', 2,)
+        ))
+
+    class TestDictSort:
+        @fixture
+        def dict_sort(self):
+            return DictSort(sort_method=sorted)
+
+        def test_it_sorts_the_dict_in_alphabetical_order_of_keys(
+            self, dict_to_sort, dict_sort, sorted_dict
+        ):
+            assert dict_sort(dict_to_sort) == sorted_dict
+
+    class TestSortedJSONField:
+        @fixture
+        def binary(self):
+            return False
+
+        @fixture
+        def sorted_json_field(self, binary):
+            return SortedJSONField(binary=binary)
+
+        def test_it_sorts_the_dict_in_alphabetical_order_of_keys(
+            self, dict_to_sort, sorted_json_field, sorted_dict
+        ):
+            assert (
+                sorted_json_field.to_representation(dict_to_sort) ==
+                sorted_dict
+            )
+
+        class TestWhenBinaryIsTrue:
+            @fixture
+            def binary(self):
+                return True
+
+            def test_it_sorts_the_dict_in_alphabetical_order_of_keys(
+                self, dict_to_sort, sorted_json_field, sorted_dict
+            ):
+                assert (
+                    sorted_json_field.to_representation(dict_to_sort) ==
+                    json.dumps(sorted_dict)
+                )


### PR DESCRIPTION
In Core I added a `SortedJSONField` serializer field in order to be able to make the order of JSON fields rendered in Pluto deterministic.

This commit migrates that change to `django-ontruck` with the following minor changes:

- The dictionary sort algorithm is no longer recursive but rather uses a queue.  This keeps the call stack height in `O(1)` wrt. the depth of the dictionary being sorted.
- The dictionary sort algorithm allows for the choice of _key_ sort algorithm to be injected.