### PR TITLE
Diff sequences as well as mappings

### DIFF
--- a/django_ontruck/utils/diff_dicts.py
+++ b/django_ontruck/utils/diff_dicts.py
@@ -211,14 +211,18 @@ class DiffDicts:
             self._enqueue(comparison.left, comparison.right, next_builder)
 
     def __call__(self, left, right):
-        builder = DictDiffBuilder()
+        try:
+            builder = DictDiffBuilder()
 
-        self._enqueue(left, right, builder)
+            self._enqueue(left, right, builder)
 
-        for comparison, current_builder in self._comparisons():
-            self._handle_comparison(comparison, current_builder)
+            for comparison, current_builder in self._comparisons():
+                self._handle_comparison(comparison, current_builder)
 
-        return builder.build()
+            return builder.build()
+
+        finally:
+            self._queue = []
 
 
 def diff_dicts(left, right, sort_method=sorted):

--- a/django_ontruck/utils/diff_dicts.py
+++ b/django_ontruck/utils/diff_dicts.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from collections import OrderedDict
+from collections import OrderedDict, Sequence, Mapping
 from dataclasses import dataclass
 from enum import Enum
 from typing import Hashable, Iterable
@@ -104,7 +104,7 @@ class DictDiff(Diff):
 
 
 def is_scalar(value):
-    return not isinstance(value, dict)
+    return not isinstance(value, (Mapping, Sequence))
 
 
 class Comparison:
@@ -159,6 +159,13 @@ class DictDiffBuilder(Builder):
         )
 
 
+def adapt_to_mapping(mapping_or_sequence):
+    if isinstance(mapping_or_sequence, Mapping):
+        return mapping_or_sequence
+
+    return {index: item for index, item in enumerate(mapping_or_sequence)}
+
+
 class DiffDicts:
     def __init__(self, sort_method):
         self.sort_method = sort_method
@@ -172,6 +179,8 @@ class DiffDicts:
                 return
 
     def _enqueue(self, left, right, builder):
+        left, right = adapt_to_mapping(left), adapt_to_mapping(right)
+
         self._queue.extend(
             [
                 (comparison, builder)

--- a/tests/test_utils/test_dict_diffs.py
+++ b/tests/test_utils/test_dict_diffs.py
@@ -18,7 +18,10 @@ def left():
             },
             'e': 3,
         },
-        'f': 4
+        'f': 4,
+        'i': [
+            7
+        ]
     }
 
 
@@ -34,7 +37,10 @@ def right():
         'f': {
             'h': 6
         },
-        'g': 5
+        'g': 5,
+        'i': [
+            8, 9
+        ]
     }
 
 
@@ -63,7 +69,18 @@ def test_diff_dict(left, right):
                     )
                 ),
                 ('f', Modification(4, {'h': 6})),
-                ('g', Addition(5))
+                ('g', Addition(5)),
+                (
+                    'i',
+                    DictDiff(
+                        OrderedDict(
+                            [
+                                (0, Modification(7, 8)),
+                                (1, Addition(9))
+                            ]
+                        )
+                    )
+                )
             ]
         )
     )
@@ -87,11 +104,13 @@ def test_iteration(left, right):
         (KeyPath('a', 'b', 'd'), Deletion(2)),
         (KeyPath('f'), Modification(4, {'h': 6})),
         (KeyPath('g'), Addition(5)),
+        (KeyPath('i', 0), Modification(7, 8)),
+        (KeyPath('i', 1), Addition(9)),
     ]
 
 
 def test_len(left, right):
-    assert len(diff_dicts(left, right)) == 4
+    assert len(diff_dicts(left, right)) == 6
 
 
 def test_key_lookup(left, right):
@@ -111,6 +130,8 @@ def test_str(left, right):
             [ - ] /a/b/d : left: 2 | right:{' '}
             [ * ] /f : left: 4 | right: {{'h': 6}}
             [ + ] /g : left:  | right: 5
+            [ * ] /i/0 : left: 7 | right: 8
+            [ + ] /i/1 : left:  | right: 9
             '''
         ).strip()
     )


### PR DESCRIPTION
A sequence can be thought of as a type of mapping with integer keys.  Use this fact to extend the `diff_dicts` method to permit sequences as well as mappings:

e.g.

```python
from django_ontruck.utils.diff_dicts import diff_dicts

str(diff_dicts({'a': [1]}, {'a': [2]}))

# [ * ] /i/0 : left: 1 | right: 2
```

**This change allows us to to diff deserialised JSON easily**