### PR TITLE
Account for the fact that str objects are also Sequences

### DIFF
--- a/django_ontruck/utils/diff_dicts.py
+++ b/django_ontruck/utils/diff_dicts.py
@@ -104,7 +104,16 @@ class DictDiff(Diff):
 
 
 def is_scalar(value):
-    return not isinstance(value, (Mapping, Sequence))
+    if isinstance(value, Mapping):
+        return False
+
+    elif not isinstance(value, Sequence):
+        return True
+
+    try:
+        return value[0][0] == value[0]
+    except (TypeError, IndexError):
+        return False
 
 
 class Comparison:

--- a/django_ontruck/utils/diff_dicts.py
+++ b/django_ontruck/utils/diff_dicts.py
@@ -18,7 +18,17 @@ missing = Missing()
 class Diff(ABC):
     @abstractmethod
     def __iter__(self):  # pragma: no cover
-        pass
+        raise NotImplementedError()
+
+    @property
+    @abstractmethod
+    def left(self):
+        raise NotImplementedError()
+
+    @property
+    @abstractmethod
+    def right(self):
+        raise NotImplementedError()
 
 
 class Symbol(Enum):
@@ -43,9 +53,17 @@ class KeyPath:
 
 class ScalarDiff(Diff, ABC):
     def __init__(self, left: object, right: object, symbol: Symbol):
-        self.left = left
-        self.right = right
+        self._left = left
+        self._right = right
         self.symbol = symbol
+
+    @property
+    def left(self):
+        return self._left
+
+    @property
+    def right(self):
+        return self._right
 
     def __iter__(self):
         yield KeyPath(), self
@@ -99,6 +117,21 @@ class DictDiff(Diff):
             f"[ {diff.symbol.value} ] {key} : {diff.description}"
             for key, diff in self
         )
+
+    def _partition(self, side):
+        return OrderedDict(
+            [
+                (key, getattr(diff, side)) for key, diff in self.items.items()
+            ]
+        )
+
+    @property
+    def left(self):
+        return self._partition('left')
+
+    @property
+    def right(self):
+        return self._partition('right')
 
     __repr__ = __str__
 

--- a/tests/test_utils/test_dict_diffs.py
+++ b/tests/test_utils/test_dict_diffs.py
@@ -4,7 +4,7 @@ from textwrap import dedent
 from pytest import fixture, mark
 
 from django_ontruck.utils.diff_dicts import (
-    Modification, Deletion, Addition, diff_dicts, DictDiff, KeyPath
+    Modification, Deletion, Addition, diff_dicts, DictDiff, KeyPath, missing
 )
 
 
@@ -168,3 +168,57 @@ def test_str(left, right):
 )
 def test_scalar_diffs_are_hashable(diff):
     assert hash(diff)
+
+
+def test_left(left, right):
+    assert diff_dicts(left, right).left == OrderedDict(
+        [
+            (
+                'a', OrderedDict(
+                    [
+                        (
+                            'b',
+                            OrderedDict([('c', 1), ('d', 2)])
+                        )
+                    ]
+                )
+            ),
+            ('f', 4),
+            ('g', missing),
+            (
+                'i',
+                OrderedDict([(0, 7), (1, missing)])
+            ),
+            (
+                'j',
+                OrderedDict([(0, 'ABCDEF')])
+            )
+        ]
+    )
+
+
+def test_right(left, right):
+    assert diff_dicts(left, right).right == OrderedDict(
+        [
+            (
+                'a',
+                OrderedDict(
+                    [
+                        (
+                            'b',
+                            OrderedDict(
+                                [
+                                    ('c', 11),
+                                    ('d', missing)
+                                ]
+                            )
+                        )
+                    ]
+                )
+            ),
+            ('f', {'h': 6}),
+            ('g', 5),
+            ('i', OrderedDict([(0, 8), (1, 9)])),
+            ('j', OrderedDict([(0, 'XYZ')]))
+        ]
+    )

--- a/tests/test_utils/test_dict_diffs.py
+++ b/tests/test_utils/test_dict_diffs.py
@@ -21,7 +21,10 @@ def left():
         'f': 4,
         'i': [
             7
-        ]
+        ],
+        'j': [
+            'ABCDEF'
+        ],
     }
 
 
@@ -40,6 +43,9 @@ def right():
         'g': 5,
         'i': [
             8, 9
+        ],
+        'j': [
+            'XYZ'
         ]
     }
 
@@ -80,7 +86,17 @@ def test_diff_dict(left, right):
                             ]
                         )
                     )
-                )
+                ),
+                (
+                    'j',
+                    DictDiff(
+                        OrderedDict(
+                            [
+                                (0, Modification('ABCDEF', 'XYZ'))
+                            ]
+                        )
+                    )
+                ),
             ]
         )
     )
@@ -106,11 +122,12 @@ def test_iteration(left, right):
         (KeyPath('g'), Addition(5)),
         (KeyPath('i', 0), Modification(7, 8)),
         (KeyPath('i', 1), Addition(9)),
+        (KeyPath('j', 0), Modification('ABCDEF', 'XYZ'))
     ]
 
 
 def test_len(left, right):
-    assert len(diff_dicts(left, right)) == 6
+    assert len(diff_dicts(left, right)) == 7
 
 
 def test_key_lookup(left, right):
@@ -120,20 +137,24 @@ def test_key_lookup(left, right):
     assert diff['a']['b']['d'] == Deletion(2)
     assert diff['f'] == Modification(4, {'h': 6})
     assert diff['g'] == Addition(5)
+    assert diff['i'][0] == Modification(7, 8)
+    assert diff['i'][1] == Addition(9)
+    assert diff['j'][0] == Modification('ABCDEF', 'XYZ')
 
 
 def test_str(left, right):
     assert (
         str(diff_dicts(left, right)) == dedent(
-            f'''
+        f'''
             [ * ] /a/b/c : left: 1 | right: 11
             [ - ] /a/b/d : left: 2 | right:{' '}
             [ * ] /f : left: 4 | right: {{'h': 6}}
             [ + ] /g : left:  | right: 5
             [ * ] /i/0 : left: 7 | right: 8
             [ + ] /i/1 : left:  | right: 9
+            [ * ] /j/0 : left: ABCDEF | right: XYZ
             '''
-        ).strip()
+    ).strip()
     )
 
 


### PR DESCRIPTION
Without the changes included here, the diff will recurse infinitely for strings since for any string `s` we have that `s[0] == s[0][0]` meaning we never reach a state of `is_scalar(s) == True` regardless of how many times we recurse.