### PR TITLE
Simplify definition of scalar

### DIFF
--- a/django_ontruck/utils/diff_dicts.py
+++ b/django_ontruck/utils/diff_dicts.py
@@ -137,16 +137,7 @@ class DictDiff(Diff):
 
 
 def is_scalar(value):
-    if isinstance(value, Mapping):
-        return False
-
-    elif not isinstance(value, Sequence):
-        return True
-
-    try:
-        return value[0][0] == value[0]
-    except (TypeError, IndexError):
-        return False
+    return not isinstance(value, (Mapping, Sequence)) or isinstance(value, str)
 
 
 class Comparison:
@@ -175,7 +166,7 @@ class Comparison:
 class Builder(ABC):
     @abstractmethod
     def build(self) -> Diff:  # pragma: no cover
-        pass
+        raise NotImplementedError()
 
 
 class ScalarBuilder(Builder):


### PR DESCRIPTION
The previous more general definition had several edge cases.  This change assumes the only recursive sequences (i.e. sequence s for which s[0][0] == s[0]) are strings.  (others will result in infinite recursions)