### PR TITLE
consumers: assure DB connection before handling messages

### DIFF
--- a/tests/test_consumers.py
+++ b/tests/test_consumers.py
@@ -1,4 +1,8 @@
+import pytest
 from .test_app.consumers import DummyConsumer, DummyExceptionConsumer
+from django_ontruck.consumer import assure_db_connection
+from django.db.utils import InterfaceError
+from django.db import connections, DatabaseError
 
 
 def test_consumer_ack(mocker):
@@ -19,3 +23,26 @@ def test_consumer_requeue(mocker):
     consumer.handle_message(body, mock_message)
 
     mock_message.requeue.assert_called_once()
+
+def test_assure_db(mocker):
+    body = "{}"
+    mock_message = mocker.Mock()
+    conns = [mocker.Mock(), mocker.Mock(), mocker.Mock(), mocker.Mock()]
+    conns[0].close_if_unusable_or_obsolete.side_effect = InterfaceError('connection already closed')
+    conns[1].close_if_unusable_or_obsolete.side_effect = DatabaseError('pgbouncer cannot connect to server SSL connection has been closed unexpectedly')
+
+    mocker.patch('django.db.connections.all', return_value= conns)
+    assure_db_connection(body, mock_message)
+
+    conns[0].close_if_unusable_or_obsolete.assert_called_with()
+    conns[1].close_if_unusable_or_obsolete.assert_called_with()
+    conns[2].close_if_unusable_or_obsolete.assert_called_with()
+
+    with pytest.raises(DatabaseError) as e_databaseerror:
+        conns = [mocker.Mock()]
+        conns[0].close_if_unusable_or_obsolete.side_effect = DatabaseError('Not expected error')
+        mocker.patch('django.db.connections.all', return_value=conns)
+        assure_db_connection(body, mock_message)
+
+
+


### PR DESCRIPTION
In order to avoid DB connection issues in  `ConsumerBase` assure DB connection is healthy before handling messages. Do mostly the same as it is done in celery official repo for standard celery task https://github.com/celery/celery/blob/7288147d65a32b726869ed887d99e4bfd8c070e2/celery/fixups/django.py#L161.

* Added as a callback before `handle_message` callback.
* Not included as a method of `ConsumerBase` in order to allow to use it to consumers not yet based on `ConsumerBase`